### PR TITLE
Fix unauthorized API request after login

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -102,6 +102,7 @@
 <script setup>
 import { ref, onMounted, watch, inject } from 'vue'
 import { useRoute, RouterView, useRouter } from 'vue-router'
+import { clearAuthToken, getAuthToken } from './tokenHandler';
 
 document.documentElement.setAttribute('data-bs-theme', 'dark')
 
@@ -110,7 +111,7 @@ const router = useRouter()
 const festivalStore = inject('festivalStore')
 
 onMounted(() => {
-  isAuthenticated.value = !!localStorage.getItem('token')
+  isAuthenticated.value = !!getAuthToken();
 
   if (!festivalStore.state.festival_id) {
     router.push('/')
@@ -122,7 +123,7 @@ const route = useRoute()
 watch(
   () => route.path,
   () => {
-    isAuthenticated.value = !!localStorage.getItem('token')
+    isAuthenticated.value = !!getAuthToken();
 
     if (!festivalStore.state.festival_id) {
       router.push('/')
@@ -132,7 +133,7 @@ watch(
 
 function logout() {
   // Clear the token from local storage
-  localStorage.removeItem('token')
+  clearAuthToken();
   festivalStore.unsetFestival()
 
   // Redirect to login page

--- a/src/components/UserLogin.vue
+++ b/src/components/UserLogin.vue
@@ -24,6 +24,7 @@
 </template>
 
 <script setup lang="ts">
+import { updateAuthToken } from '@/tokenHandler';
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -51,8 +52,13 @@ async function login() {
     }
 
     const data = await response.json()
-    localStorage.setItem('token', data.token) // Assuming the response contains a token field
-    router.push('/')
+
+    // Assuming the response contains a token field
+    if(data.token)
+    {
+      updateAuthToken(data.token);
+    }
+    router.push('/');
   } catch (error: unknown) {
     if (error instanceof Error) {
       alert(error.message)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
 import { createApp, reactive } from 'vue'
 import App from './App.vue'
 import router from './router'
-import axios from 'axios'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap'
 import { createFestivalStore } from './helpers/festival.store'
+import { updateAuthToken, getAuthToken } from './tokenHandler'
 
 const app = createApp(App)
 
@@ -19,17 +19,8 @@ app.use(router)
 
 app.mount('#app')
 
-// Function to set authorization token
-function setAuthToken(token: string) {
-  if (token) {
-    axios.defaults.headers.common['Authorization'] = `Bearer ${token}`
-  } else {
-    delete axios.defaults.headers.common['Authorization']
-  }
-}
-
 // Set the token at startup
-const token = localStorage.getItem('token')
-if (token) {
-  setAuthToken(token)
+let token = getAuthToken();
+if (token !== null) {
+  updateAuthToken(token)
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import ProductsOverview from '../components/ProductsOverview.vue'
 import VendingPointOverview from '../components/VendingPointOverview.vue'
 import Login from '../components/UserLogin.vue'
 import FestivalsOverview from '../components/FestivalsOverview.vue'
+import { clearAuthToken, getAuthToken } from '@/tokenHandler'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -42,7 +43,7 @@ const router = createRouter({
 })
 
 router.beforeEach((to, from, next) => {
-  const token = localStorage.getItem('token')
+  const token = getAuthToken();
   if (to.meta.requiresAuth && !token) {
     next({ name: 'login' })
   } else if (token) {
@@ -50,7 +51,7 @@ router.beforeEach((to, from, next) => {
     const jwtPayload = parseJwt(token)
     if (jwtPayload.exp < Date.now() / 1000) {
       // token expired
-      localStorage.removeItem('token') // Remove expired token
+      clearAuthToken(); // Remove expired token
       next({ name: 'login' })
     } else {
       next()

--- a/src/tokenHandler.ts
+++ b/src/tokenHandler.ts
@@ -1,0 +1,25 @@
+import axios from 'axios'
+
+const storageTokenName = 'token';
+
+// Function to set authorization token
+export function updateAuthToken(token: string | null): void
+{
+    if (token !== null) {
+        localStorage.setItem(storageTokenName, token);
+        axios.defaults.headers.common['Authorization'] = `Bearer ${token}`
+    } else {
+        delete axios.defaults.headers.common['Authorization']
+    }
+}
+
+export function getAuthToken(): string | null
+{
+    return localStorage.getItem(storageTokenName);
+}
+
+export function clearAuthToken(): void
+{
+    localStorage.removeItem(storageTokenName);
+    updateAuthToken(getAuthToken());
+}


### PR DESCRIPTION
After successful login, the token was not directly set for the API requests.

Therefor the handling of the token is now in a separate place where all necessary stuff is handled.